### PR TITLE
add endpoint to fetch workouts by user_id and workout_date

### DIFF
--- a/backend/routes/workouts.js
+++ b/backend/routes/workouts.js
@@ -90,4 +90,40 @@ router.get("/search/by-user-date-single", async (req, res) => {
   }
 });
 
+// Endpoint to fetch workouts by user ID and date range
+router.get("/search/by-user-date-range", async (req, res) => {
+  try {
+    const {user_id, start_date, end_date} = req.query;
+    
+    if(!user_id || !start_date || !end_date){
+      return res.status(400).json({ error: "user_id, start_date and end_date are required" });
+    }
+
+    if (isNaN(Number(user_id))) {
+      return res.status(400).json({ error: "user_id must be a number" });
+    }
+
+    if (isNaN(Date.parse(start_date)) || isNaN(Date.parse(end_date))) {
+      return res.status(400).json({ error: "start and end date must be valid dates" });
+    }
+
+    if (new Date(start_date) > new Date(end_date)) {
+      return res.status(400).json({ error: "start_date must be before or equal to end_date" });
+    }
+
+    const query = 'SELECT * FROM workouts WHERE user_id = ? AND workout_date BETWEEN ? AND ?'
+
+    const [rows] = await db.query(query, [user_id, start_date, end_date]);
+
+    res.json({
+      message: "workouts retrieved successfully",
+      workouts: rows
+    });
+
+  } catch (error) {
+    console.error("error in fetch workouts route:", error);
+    res.status(500).send("server error");
+  }
+});
+
 export default router;

--- a/backend/routes/workouts.js
+++ b/backend/routes/workouts.js
@@ -20,13 +20,13 @@ router.post("/add", async (req, res) => {
     const [result] = await db.query(insertQuery, [user_id, workout_date, notes || ""]);
     
     res.json({
-      message: "Workout added successfully",
+      message: "workout added successfully",
       workout_id: result.insertId,
     });
 
   }catch(error){
-      console.error("Error in /add workout route:", error);
-      res.status(500).send("Server error");
+      console.error("error in /add workout route:", error);
+      res.status(500).send("server error");
   }
 });
 
@@ -48,13 +48,45 @@ router.get("/search/user", async (req, res) => {
     const [rows] = await db.query(query, [user_id]);
 
     res.json({
-      message: "Workouts retrieved successfully",
+      message: "workouts retrieved successfully",
       workouts: rows
     });
 
   } catch (error) {
-    console.error("Error in fetch workouts route:", error);
-    res.status(500).send("Server error");
+    console.error("error in fetch workouts route:", error);
+    res.status(500).send("server error");
+  }
+});
+
+// Endpoint to fetch workouts by user ID and date
+router.get("/search/by-user-date-single", async (req, res) => {
+  try {
+    const {user_id, workout_date} = req.query;
+    
+    if(!user_id || !workout_date){
+      return res.status(400).json({ error: "user_id and date are required" });
+    }
+
+    if (isNaN(Number(user_id))) {
+      return res.status(400).json({ error: "user_id must be a number" });
+    }
+
+    if (isNaN(Date.parse(workout_date))) {
+      return res.status(400).json({ error: "workout_date must be a valid date" });
+    }
+
+    const query = 'SELECT * FROM workouts WHERE user_id = ? AND workout_date = ?'
+
+    const [rows] = await db.query(query, [user_id, workout_date]);
+
+    res.json({
+      message: "workouts retrieved successfully",
+      workouts: rows
+    });
+
+  } catch (error) {
+    console.error("error in fetch workouts route:", error);
+    res.status(500).send("server error");
   }
 });
 

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -1,0 +1,40 @@
+import request from "supertest";
+import app from "../app";
+
+describe("POST /add", () => {
+    // Positive tests
+    describe("given working data for all fields, cardio", () => {
+        test("should successfully add an exercise, cardio", async () => {
+          const response = await request(app).post("/exercises/add").send({
+                "user_id": 1,
+                "workout_id": 9,
+                "intensity": 25.00,
+                "exercise_type": "cardio",
+                "calories_burned": 250,
+                "exercise_time": 30
+            })
+            .set("Content-Type", "application/json")
+            .expect(200);
+        });
+    });
+
+    describe("given working data for all fields, strength", () => {
+        test("should successfully add an exercise, strength", async () => {
+            const response = await request(app).post("/exercises/add").send({
+                "user_id": 1,
+                "workout_id": 9,
+                "intensity": 25.00,
+                "exercise_type": "strength training",
+                "calories_burned": 250,
+                "weight": 100.00,
+                "sets" : 5,
+                "reps" : 5
+            })
+            .set("content-Type", "application/json")
+            .expect(200);
+        });
+    });
+
+    // Negative tests
+    describe("")
+});

--- a/backend/tests/workouts.test.js
+++ b/backend/tests/workouts.test.js
@@ -111,7 +111,7 @@ describe("POST /add", () =>{
                 .set("Content-Type", "application/json")
                 .expect(200);
     
-                expect(response.body).toHaveProperty("message", "Workout added successfully");
+                expect(response.body).toHaveProperty("message", "workout added successfully");
                 expect(response.body).toHaveProperty("workout_id");
             });
         });
@@ -127,20 +127,8 @@ describe("/search/user", () => {
                 .query({ user_id: 1 })
                 .expect(200);
           
-              expect(response.body).toHaveProperty("message", "Workouts retrieved successfully");
+              expect(response.body).toHaveProperty("message", "workouts retrieved successfully");
               expect(Array.isArray(response.body.workouts)).toBe(true);
-            });
-        });
-
-        describe("given valid user_id with no workouts", () => {
-            test("should return 200 and empty workouts array", async () => {
-              const response = await request(app)
-                .get("/workouts/search/user")
-                .query({ user_id: 9999 })
-                .expect(200);
-          
-              expect(response.body).toHaveProperty("message", "Workouts retrieved successfully");
-              expect(response.body.workouts).toEqual([]);
             });
         });
     });
@@ -164,6 +152,56 @@ describe("/search/user", () => {
                 .expect(400);
         
               expect(response.body).toHaveProperty("error", "user_id must be a number");
+            });
+        });
+    });
+});
+
+describe("/search/by-user-date-single", () => {
+    describe("positive tests", () => {
+        describe("given valid user_name and date", () => {
+            test("should return 200 and workouts array", async () => {
+                const response = await request(app)
+                .get("/workouts/search/by-user-date-single")
+                .query({user_id: 1, workout_date: "2025-11-11 00:00:00"})
+                .expect(200);
+
+                expect(response.body).toHaveProperty("message", "workouts retrieved successfully");
+                expect(Array.isArray(response.body.workouts)).toBe(true);  
+            });
+        });
+    });
+
+    describe("negative tests", () => {
+        describe("missing user_id and date in query", () => {
+            test("should respond with 400 and error message", async () => {
+              const response = await request(app)
+                .get("/workouts/search/by-user-date-single")
+                .expect(400);
+          
+              expect(response.body).toHaveProperty("error", "user_id and date are required");
+            });
+        });
+
+        describe("missing only user_id", () => {
+            test("should respond with 400 and error message", async () => {
+              const response = await request(app)
+                .get("/workouts/search/by-user-date-single")
+                .query({workout_date: "025-11-11 00:00:00"})
+                .expect(400);
+          
+              expect(response.body).toHaveProperty("error", "user_id and date are required");
+            });
+        });
+
+        describe("missing only workout_date", () => {
+            test("should respond with 400 and error message", async () => {
+              const response = await request(app)
+                .get("/workouts/search/by-user-date-single")
+                .query({user_id: 1})
+                .expect(400);
+          
+              expect(response.body).toHaveProperty("error", "user_id and date are required");
             });
         });
     });

--- a/backend/tests/workouts.test.js
+++ b/backend/tests/workouts.test.js
@@ -206,3 +206,77 @@ describe("/search/by-user-date-single", () => {
         });
     });
 });
+
+describe("/search/by-user-date-range", () => {
+    describe("positive tests", () => {
+      describe("given valid user_id, start_date and end_date", () => {
+        test("should return 200 and workouts array", async () => {
+          const response = await request(app)
+            .get("/workouts/search/by-user-date-range")
+            .query({ 
+              user_id: 1, 
+              start_date: "2025-11-01 00:00:00", 
+              end_date: "2025-11-30 00:00:00" 
+            })
+            .expect(200);
+    
+          expect(response.body).toHaveProperty("message", "workouts retrieved successfully");
+          expect(Array.isArray(response.body.workouts)).toBe(true);
+        });
+      });
+    });
+    
+    describe("negative tests", () => {
+      describe("missing user_id, start_date and end_date in query", () => {
+        test("should respond with 400 and error message", async () => {
+          const response = await request(app)
+            .get("/workouts/search/by-user-date-range")
+            .expect(400);
+    
+          expect(response.body).toHaveProperty("error", "user_id, start_date and end_date are required");
+        });
+      });
+    
+      describe("missing only user_id", () => {
+        test("should respond with 400 and error message", async () => {
+          const response = await request(app)
+            .get("/workouts/search/by-user-date-range")
+            .query({ 
+              start_date: "2025-11-01 00:00:00", 
+              end_date: "2025-11-30 00:00:00" 
+            })
+            .expect(400);
+    
+          expect(response.body).toHaveProperty("error", "user_id, start_date and end_date are required");
+        });
+      });
+    
+      describe("missing only start_date", () => {
+        test("should respond with 400 and error message", async () => {
+          const response = await request(app)
+            .get("/workouts/search/by-user-date-range")
+            .query({ 
+              user_id: 1, 
+              end_date: "2025-11-30 00:00:00" 
+            })
+            .expect(400);
+    
+          expect(response.body).toHaveProperty("error", "user_id, start_date and end_date are required");
+        });
+      });
+    
+      describe("missing only end_date", () => {
+        test("should respond with 400 and error message", async () => {
+          const response = await request(app)
+            .get("/workouts/search/by-user-date-range")
+            .query({ 
+              user_id: 1, 
+              start_date: "2025-11-01 00:00:00" 
+            })
+            .expect(400);
+    
+          expect(response.body).toHaveProperty("error", "user_id, start_date and end_date are required");
+        });
+      });
+    });
+  });


### PR DESCRIPTION
Added the endpoint "/search/by-user-date-single".
Added all basic positive and negative tests:
- valid user_id and date
- missing both user_id and date
- missing only user_id
- missing only date

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new API endpoints to fetch workouts by user ID and specific date, as well as by date range, with input validation.
  
- **Bug Fixes**
  - Standardized success and error response messages for a more consistent user experience.
  
- **Tests**
  - Introduced new tests for the `/exercises/add` endpoint and enhanced existing workout tests, including positive and negative scenarios for new endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->