### PR TITLE
Add endpoint and unit tests for get exercises from user_id and date range (#22)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -5,6 +5,7 @@ import cookieParser from "cookie-parser"; // Import cookie-parser
 import foodItemsRoutes from "./routes/food_items.js"; // Import the routes
 import progress from "./routes/progress.js"; // Import the routes
 import workoutsRoutes from "./routes/workouts.js";
+import exercisesRoutes from "./routes/exercises.js";
 
 dotenv.config();
 
@@ -26,6 +27,8 @@ app.use("/food_items", foodItemsRoutes);
 app.use("/progress", progress);
 
 app.use("/workouts", workoutsRoutes);
+
+app.use("/exercises", exercisesRoutes);
 
 app.get("/", (req, res) => {
   res.send("Backend is running!");

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,9 +1,9 @@
 import express from "express";
 import cors from "cors";
 import dotenv from "dotenv";
-import cookieParser from "cookie-parser"; // Import cookie-parser
-import foodItemsRoutes from "./routes/food_items.js"; // Import the routes
-import progress from "./routes/progress.js"; // Import the routes
+import cookieParser from "cookie-parser";
+import foodItemsRoutes from "./routes/food_items.js"; 
+import progress from "./routes/progress.js";
 import workoutsRoutes from "./routes/workouts.js";
 import exercisesRoutes from "./routes/exercises.js";
 
@@ -13,17 +13,17 @@ const app = express();
 
 app.use(
   cors({
-    origin: true, // Replace with your frontend's origin
-    credentials: true, // Allow cookies and credentials
+    origin: true,
+    credentials: true,
   }),
 );
-app.use(cookieParser()); // Use cookie-parser separately
+app.use(cookieParser());
 app.use(express.json());
 
-// Middleware to use food items routes
+// Middleware
+
 app.use("/food_items", foodItemsRoutes);
 
-// Middleware to use progress routes
 app.use("/progress", progress);
 
 app.use("/workouts", workoutsRoutes);

--- a/backend/routes/exercises.js
+++ b/backend/routes/exercises.js
@@ -162,11 +162,11 @@ router.post("/update", async (req, res) => {
     }
 });
 
-router.get("/search/user", async (req, res) => {
+router.get("/search/exercise", async (req, res) => {
     try {
-        const { user_id } = req.body;
-        if (!user_id) {
-            return res.status(400).json({ error: "user_id is required" });
+        const { exercise_id } = req.body;
+        if (!exercise_id) {
+            return res.status(400).json({ error: "exercise_id is required" });
         }
 
         const query = `
@@ -182,13 +182,13 @@ router.get("/search/user", async (req, res) => {
             FROM exercises e
             LEFT JOIN calisthenics_exercises ce ON e.exercise_id = ce.exercise_id
             LEFT JOIN weight_exercises we ON e.exercise_id = we.exercise_id
-            WHERE e.user_id = ?
+            WHERE e.exercise_id = ?
         `;
         
-        const [rows] = await db.query(query, [user_id]);
+        const [rows] = await db.query(query, [exercise_id]);
         res.json({ exercises: rows });
     } catch (error) {
-        console.error("Error in GET /user/:user_id/exercises:", error);
+        console.error("Error in /search/exercise route:", error);
         res.status(500).send("Server error");
     }
 });

--- a/backend/routes/exercises.js
+++ b/backend/routes/exercises.js
@@ -1,0 +1,100 @@
+import express from "express";
+import db from "../db.js";
+const router = express.Router();
+
+router.post("/add", async (req, res) => {
+    try{
+        const {
+            user_id,
+            workout_id,
+            intensity,
+            exercise_type,
+            calories_burned
+        } = req.body;
+
+        let exercise_time;
+        let weight;
+        let sets;
+        let reps;
+        let additionalData = {};
+
+        if(exercise_type === "cardio"){
+            exercise_time = req.body.exercise_time;
+            additionalData = { exercise_time };
+        }
+
+        if(exercise_type === "strength training"){
+            weight = req.body.weight;
+            sets = req.body.sets;
+            reps = req.body.reps;
+            additionalData = { weight, sets, reps};
+        }
+
+        const completeData = {
+            user_id,
+            workout_id,
+            intensity,
+            exercise_type,
+            calories_burned,
+            ...additionalData
+        };
+
+        if (!user_id || !workout_id || !intensity || !exercise_type) {
+            return res.status(400).json({ error: "user_id, workout_id, intensity, and exercise_type are required" });
+        }
+
+        if(exercise_type != "cardio" && exercise_type != "strength training"){
+            return res.status(400).json({error: "exercise_type must be 'cardio' or 'strength training'"});
+        }
+
+        if(exercise_type === "cardio"){
+            if(!exercise_time){
+                return res.status(400).json({error: "cardio exercises must have an excercise_time"});
+            }
+        }
+
+        if(exercise_type === "strength training"){
+            if(!weight || !sets || !reps){
+                return res.status(400).json({error: "strength training excercises must have weight, sets, and reps"});
+            }
+        }
+
+        if(calories_burned <= 0){
+            return res.status(400).json({error: "an excercise must have a positive int for calories_burned"});
+        }
+
+        const insertQuery = `
+            INSERT INTO exercises (user_id, workout_id, intensity, exercise_type, calories_burned)
+            VALUES (?, ?, ?, ?, ?)
+        `;
+
+        const [result] = await db.query(insertQuery, [user_id, workout_id, intensity, exercise_type, calories_burned]);
+        const exercise_id = result.insertId;
+
+        if(exercise_type === "cardio"){
+            const cardioInsertQuery = `
+                INSERT INTO calisthenics_exercises (exercise_id, exercise_time)
+                VALUES (?, ?)
+            `;
+            await db.query(cardioInsertQuery, [exercise_id, exercise_time]);
+        }
+
+        if(exercise_type === "strength training"){
+            const strengthInsertQuery = `
+                INSERT INTO weight_exercises (exercise_id, weight, sets, reps)
+                VALUES (?, ?, ?, ?)
+            `;
+            await db.query(strengthInsertQuery, [exercise_id, weight, sets, reps]);
+        }
+
+        res.json({
+            message: "Exercise added successfully",
+            exercise_id: exercise_id,
+        });
+    }catch(error){
+        console.error("Error in /add exercise route:", error);
+        res.status(500).send("Server error");
+    }
+  });
+
+export default router;

--- a/backend/routes/exercises.js
+++ b/backend/routes/exercises.js
@@ -162,4 +162,35 @@ router.post("/update", async (req, res) => {
     }
 });
 
+router.get("/search/user", async (req, res) => {
+    try {
+        const { user_id } = req.body;
+        if (!user_id) {
+            return res.status(400).json({ error: "user_id is required" });
+        }
+
+        const query = `
+            SELECT 
+                e.exercise_id,
+                e.intensity,
+                e.exercise_type,
+                e.calories_burned,
+                ce.exercise_time,
+                we.weight,
+                we.sets,
+                we.reps
+            FROM exercises e
+            LEFT JOIN calisthenics_exercises ce ON e.exercise_id = ce.exercise_id
+            LEFT JOIN weight_exercises we ON e.exercise_id = we.exercise_id
+            WHERE e.user_id = ?
+        `;
+        
+        const [rows] = await db.query(query, [user_id]);
+        res.json({ exercises: rows });
+    } catch (error) {
+        console.error("Error in GET /user/:user_id/exercises:", error);
+        res.status(500).send("Server error");
+    }
+});
+
 export default router;

--- a/backend/routes/exercises.js
+++ b/backend/routes/exercises.js
@@ -164,9 +164,9 @@ router.post("/update", async (req, res) => {
 
 router.get("/search/exercise", async (req, res) => {
     try {
-        const { exercise_id } = req.body;
-        if (!exercise_id) {
-            return res.status(400).json({ error: "exercise_id is required" });
+        const { workout_id } = req.body;
+        if (!workout_id) {
+            return res.status(400).json({ error: "workout_id is required" });
         }
 
         const query = `
@@ -182,10 +182,10 @@ router.get("/search/exercise", async (req, res) => {
             FROM exercises e
             LEFT JOIN calisthenics_exercises ce ON e.exercise_id = ce.exercise_id
             LEFT JOIN weight_exercises we ON e.exercise_id = we.exercise_id
-            WHERE e.exercise_id = ?
+            WHERE e.workout_id = ?
         `;
         
-        const [rows] = await db.query(query, [exercise_id]);
+        const [rows] = await db.query(query, [workout_id]);
         res.json({ exercises: rows });
     } catch (error) {
         console.error("Error in /search/exercise route:", error);

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -2,35 +2,155 @@ import request from "supertest";
 import app from "../app";
 
 describe("POST /add", () => {
-    describe("given working data for all fields, cardio", () => {
-        test("should successfully add an exercise, cardio", async () => {
-          const response = await request(app).post("/exercises/add").send({
-                "user_id": 1,
-                "workout_id": 9,
-                "intensity": 25.00,
-                "exercise_type": "cardio",
-                "calories_burned": 250,
-                "exercise_time": 30
-            })
-            .set("Content-Type", "application/json")
-            .expect(200);
+    describe("positive tests", () => {
+        describe("given working data for all fields, cardio", () => {
+            test("should successfully add an exercise, cardio", async () => {
+              const response = await request(app).post("/exercises/add").send({
+                    "user_id": 1,
+                    "workout_id": 9,
+                    "intensity": 25.00,
+                    "exercise_type": "cardio",
+                    "calories_burned": 250,
+                    "exercise_time": 30
+                })
+                .set("Content-Type", "application/json")
+                .expect(200);
+            });
+        });
+        
+        describe("given working data for all fields, strength", () => {
+            test("should successfully add an exercise, strength", async () => {
+                const response = await request(app).post("/exercises/add").send({
+                    "user_id": 1,
+                    "workout_id": 9,
+                    "intensity": 25.00,
+                    "exercise_type": "strength training",
+                    "calories_burned": 250,
+                    "weight": 100.00,
+                    "sets" : 5,
+                    "reps" : 5
+                })
+                .set("content-Type", "application/json")
+                .expect(200);
+            });
         });
     });
-    
-    describe("given working data for all fields, strength", () => {
-        test("should successfully add an exercise, strength", async () => {
-            const response = await request(app).post("/exercises/add").send({
-                "user_id": 1,
-                "workout_id": 9,
-                "intensity": 25.00,
-                "exercise_type": "strength training",
-                "calories_burned": 250,
-                "weight": 100.00,
-                "sets" : 5,
-                "reps" : 5
+    describe("negative tests", () => {
+        test("should fail when required fields are missing", async () => {
+            // Missing user_id, workout_id, and intensity (only exercise_type and calories_burned provided)
+            const response = await request(app)
+            .post("/exercises/add")
+            .send({
+                exercise_type: "cardio",
+                calories_burned: 250,
+                exercise_time: 30,
             })
-            .set("content-Type", "application/json")
-            .expect(200);
+            .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("user_id, workout_id, intensity, and exercise_type are required");
+        });
+        
+        test("should fail when exercise_type is invalid", async () => {
+            const response = await request(app)
+            .post("/exercises/add")
+            .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "yoga", // invalid exercise type
+                calories_burned: 250,
+            })
+            .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("exercise_type must be 'cardio' or 'strength training'");
+        });
+        
+        test("should fail when cardio exercise is missing exercise_time", async () => {
+            const response = await request(app)
+            .post("/exercises/add")
+            .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "cardio",
+                calories_burned: 250,
+                // exercise_time is missing
+            })
+            .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("cardio exercises must have an excercise_time");
+        });
+        
+        describe("strength training negative tests", () => {
+            test("should fail when weight is missing", async () => {
+            const response = await request(app)
+                .post("/exercises/add")
+                .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "strength training",
+                calories_burned: 250,
+                sets: 5,
+                reps: 5,
+                // weight is missing
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("strength training excercises must have weight, sets, and reps");
+            });
+        
+            test("should fail when sets is missing", async () => {
+            const response = await request(app)
+                .post("/exercises/add")
+                .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "strength training",
+                calories_burned: 250,
+                weight: 100.0,
+                reps: 5,
+                // sets is missing
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("strength training excercises must have weight, sets, and reps");
+            });
+        
+            test("should fail when reps is missing", async () => {
+            const response = await request(app)
+                .post("/exercises/add")
+                .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "strength training",
+                calories_burned: 250,
+                weight: 100.0,
+                sets: 5,
+                // reps is missing
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("strength training excercises must have weight, sets, and reps");
+            });
+        });
+        
+        test("should fail when calories_burned is not positive", async () => {
+            const response = await request(app)
+            .post("/exercises/add")
+            .send({
+                user_id: 1,
+                workout_id: 9,
+                intensity: 25.0,
+                exercise_type: "cardio",
+                calories_burned: 0, // non-positive value
+                exercise_time: 30,
+            })
+            .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("an excercise must have a positive int for calories_burned");
         });
     });
 });

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -1,0 +1,19 @@
+import request from "supertest";
+import app from "../app";
+
+describe("POST /add", () => {
+    describe("given working data for all fields, cardio", () => {
+        test("should successfully add an exercise", async () => {
+          const response = await request(app).post("/exercises/add").send({
+                "user_id": 1,
+                "workout_id": 9,
+                "intensity": 25.00,
+                "exercise_type": "cardio",
+                "calories_burned": 250,
+                "exercise_time": 30
+            })
+            .set("Content-Type", "application/json")
+            .expect(200);
+        });
+    });
+});

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -311,7 +311,7 @@ describe("/search/exercise", () => {
         test("should return exercise details for a valid exercise_id", async () => {
             const response = await request(app)
                 .get("/exercises/search/exercise")
-                .send({ exercise_id: 1 })
+                .send({ workout_id: 1 })
                 .set("Content-Type", "application/json");
 
             expect(response.status).toBe(200);
@@ -328,7 +328,7 @@ describe("/search/exercise", () => {
                 .set("Content-Type", "application/json");
 
             expect(response.status).toBe(400);
-            expect(response.body.error).toMatch("exercise_id is required");
+            expect(response.body.error).toMatch("workout_id is required");
         });
     });
 });

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -305,3 +305,30 @@ describe("/update", () => {
         });
     });
 });
+
+describe("/search/exercise", () => {
+    describe("positive tests", () => {
+        test("should return exercise details for a valid exercise_id", async () => {
+            const response = await request(app)
+                .get("/exercises/search/exercise")
+                .send({ exercise_id: 1 })
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty("exercises");
+            expect(Array.isArray(response.body.exercises)).toBe(true);
+        });
+    });
+
+    describe("negative tests", () => {
+        test("should fail when exercise_id is missing", async () => {
+            const response = await request(app)
+                .get("/exercises/search/exercise")
+                .send({})
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("exercise_id is required");
+        });
+    });
+});

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -3,7 +3,7 @@ import app from "../app";
 
 describe("POST /add", () => {
     describe("given working data for all fields, cardio", () => {
-        test("should successfully add an exercise", async () => {
+        test("should successfully add an exercise, cardio", async () => {
           const response = await request(app).post("/exercises/add").send({
                 "user_id": 1,
                 "workout_id": 9,
@@ -13,6 +13,23 @@ describe("POST /add", () => {
                 "exercise_time": 30
             })
             .set("Content-Type", "application/json")
+            .expect(200);
+        });
+    });
+    
+    describe("given working data for all fields, strength", () => {
+        test("should successfully add an exercise, strength", async () => {
+            const response = await request(app).post("/exercises/add").send({
+                "user_id": 1,
+                "workout_id": 9,
+                "intensity": 25.00,
+                "exercise_type": "strength training",
+                "calories_burned": 250,
+                "weight": 100.00,
+                "sets" : 5,
+                "reps" : 5
+            })
+            .set("content-Type", "application/json")
             .expect(200);
         });
     });

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -332,3 +332,63 @@ describe("/search/exercise", () => {
         });
     });
 });
+
+describe("/search/user-date-range", () => {
+    describe("positive tests", () => {
+        test("should return exercise details for a valid user_id and date range", async () => {
+            const response = await request(app)
+                .get("/exercises/search/user-date-range")
+                .send({
+                    user_id: 1,
+                    start_date: "2021-01-01",
+                    end_date: "2021-01-31"
+                })
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(200);
+            expect(response.body).toHaveProperty("exercises");
+            expect(Array.isArray(response.body.exercises)).toBe(true);
+        });
+    });
+
+    describe("negative tests", () => {
+        test("should fail when user_id is missing", async () => {
+            const response = await request(app)
+                .get("/exercises/search/user-date-range")
+                .send({
+                    start_date: "2021-01-01",
+                    end_date: "2021-01-31"
+                })
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("user_id, start_date, and end_date are required");
+        });
+
+        test("should fail when start_date is missing", async () => {
+            const response = await request(app)
+                .get("/exercises/search/user-date-range")
+                .send({
+                    user_id: 1,
+                    end_date: "2021-01-31"
+                })
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("user_id, start_date, and end_date are required");
+        });
+
+        test("should fail when end_date is missing", async () => {
+            const response = await request(app)
+                .get("/exercises/search/user-date-range")
+                .send({
+                    user_id: 1,
+                    start_date: "2021-01-01"
+                })
+                .set("Content-Type", "application/json");
+
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("user_id, start_date, and end_date are required");
+        });
+    });
+});

--- a/backend/tests/exercises.test.js
+++ b/backend/tests/exercises.test.js
@@ -1,7 +1,7 @@
 import request from "supertest";
 import app from "../app";
 
-describe("POST /add", () => {
+describe("/add", () => {
     describe("positive tests", () => {
         describe("given working data for all fields, cardio", () => {
             test("should successfully add an exercise, cardio", async () => {
@@ -151,6 +151,157 @@ describe("POST /add", () => {
             .set("Content-Type", "application/json");
             expect(response.status).toBe(400);
             expect(response.body.error).toMatch("an excercise must have a positive int for calories_burned");
+        });
+    });
+});
+
+describe("/update", () => {
+    describe("positive tests", () => {
+        test("should successfully update a cardio exercise", async () => {
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    exercise_id: 1,
+                    intensity: 30,
+                    exercise_type: "cardio",
+                    calories_burned: 300,
+                    exercise_time: 45
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe("Exercise updated successfully");
+            expect(response.body.exercise_id).toBe(1);
+        });
+
+        test("should successfully update a strength training exercise", async () => {
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    exercise_id: 2,
+                    intensity: 40,
+                    exercise_type: "strength training",
+                    calories_burned: 400,
+                    weight: 150,
+                    sets: 3,
+                    reps: 10
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(200);
+            expect(response.body.message).toBe("Exercise updated successfully");
+            expect(response.body.exercise_id).toBe(2);
+        });
+    });
+
+    describe("negative tests", () => {
+        test("should fail when required fields are missing", async () => {
+            // Missing exercise_id, intensity, and exercise_type
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    calories_burned: 300,
+                    exercise_time: 45
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("exercise_id, intensity, and exercise_type are required");
+        });
+
+        test("should fail when exercise_type is invalid", async () => {
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    exercise_id: 1,
+                    intensity: 30,
+                    exercise_type: "yoga", // invalid type
+                    calories_burned: 300,
+                    exercise_time: 45
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("exercise_type must be 'cardio' or 'strength training'");
+        });
+
+        test("should fail when calories_burned is not positive", async () => {
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    exercise_id: 1,
+                    intensity: 30,
+                    exercise_type: "cardio",
+                    calories_burned: 0, // non-positive value
+                    exercise_time: 45
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("an exercise must have a positive int for calories_burned");
+        });
+
+        test("should fail when cardio exercise is missing exercise_time", async () => {
+            const response = await request(app)
+                .post("/exercises/update")
+                .send({
+                    exercise_id: 1,
+                    intensity: 30,
+                    exercise_type: "cardio",
+                    calories_burned: 300
+                    // missing exercise_time
+                })
+                .set("Content-Type", "application/json");
+            expect(response.status).toBe(400);
+            expect(response.body.error).toMatch("cardio exercises must have an exercise_time");
+        });
+
+        describe("strength training negative tests", () => {
+            test("should fail when weight is missing", async () => {
+                const response = await request(app)
+                    .post("/exercises/update")
+                    .send({
+                        exercise_id: 2,
+                        intensity: 40,
+                        exercise_type: "strength training",
+                        calories_burned: 400,
+                        sets: 3,
+                        reps: 10
+                        // missing weight
+                    })
+                    .set("Content-Type", "application/json");
+                expect(response.status).toBe(400);
+                expect(response.body.error).toMatch("strength training exercises must have weight, sets, and reps");
+            });
+
+            test("should fail when sets is missing", async () => {
+                const response = await request(app)
+                    .post("/exercises/update")
+                    .send({
+                        exercise_id: 2,
+                        intensity: 40,
+                        exercise_type: "strength training",
+                        calories_burned: 400,
+                        weight: 150,
+                        reps: 10
+                        // missing sets
+                    })
+                    .set("Content-Type", "application/json");
+                expect(response.status).toBe(400);
+                expect(response.body.error).toMatch("strength training exercises must have weight, sets, and reps");
+            });
+
+            test("should fail when reps is missing", async () => {
+                const response = await request(app)
+                    .post("/exercises/update")
+                    .send({
+                        exercise_id: 2,
+                        intensity: 40,
+                        exercise_type: "strength training",
+                        calories_burned: 400,
+                        weight: 150,
+                        sets: 3
+                        // missing reps
+                    })
+                    .set("Content-Type", "application/json");
+                expect(response.status).toBe(400);
+                expect(response.body.error).toMatch("strength training exercises must have weight, sets, and reps");
+            });
         });
     });
 });


### PR DESCRIPTION
Implements the "get exercises from user_id and date range" endpoint in the backend as part of the larger implement Exercises Routes issue (#19)

- Created a new endpoint, /search/user-date-range, in routes/exercises.js
- Added validation for required fields in the request bodyy
- Wrote unit tests in tests/exercises.test.js to cover normal and edge cases.

Closes #22 (sub-issue) of #19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new exercise management capabilities that allow users to add, update, and retrieve exercise records, including filtering by workout details and date ranges.
- **Tests**
  - Implemented comprehensive test scenarios covering the exercise management functionalities to ensure reliable and robust performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->